### PR TITLE
Disable vulnerability split PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -357,5 +357,8 @@
                 "/^xunit.*/"
             ]
         }
-    ]
+    ],
+    "vulnerabilityAlerts": {
+        "enabled": false
+    }
 }


### PR DESCRIPTION
vulnerability alerts break grouping and cause build failures where packages are linked but no longer grouped